### PR TITLE
Fix iMac capitalization in category lists

### DIFF
--- a/gemini.py
+++ b/gemini.py
@@ -15,7 +15,7 @@ def gemini_prompt(prompt):
     return response
 
 category_name = gemini_prompt("""Given the following technology model,Model: Dell Chromebook 11 (3180) select the most appropriate category from this list:
-IMac,Tablets,Mobile Devices,Servers,Networking Equipment,Printers & Scanners,Desktop,Chromebook
+iMac,Tablets,Mobile Devices,Servers,Networking Equipment,Printers & Scanners,Desktop,Chromebook
 """).text
 category_name = category_name.split('**')[1]
 print(category_name)

--- a/snipe-IT.py
+++ b/snipe-IT.py
@@ -213,7 +213,7 @@ def create_hardware(asset_tag, status_name, model_name, macAddress, createdDate,
             model_id = default_model_id
         else:
             category_name = gemini.gemini_prompt(f"""Given the following technology model,Model: {model_name} select the most appropriate category from this list:
-IMac,Tablets,Mobile Devices,Servers,Networking Equipment,Printers & Scanners,Desktop,Chromebook
+iMac,Tablets,Mobile Devices,Servers,Networking Equipment,Printers & Scanners,Desktop,Chromebook
 """).text  
 
             if '**' in category_name:


### PR DESCRIPTION
## Summary
- update category strings to use `iMac` instead of `IMac`

## Testing
- `python -m py_compile snipe-IT.py gemini.py`

------
https://chatgpt.com/codex/tasks/task_e_684c2a9b37bc8333ba5570d3bb135add